### PR TITLE
[STYLE/#2] : 거래 내역 리스트(하단부) UI 구현

### DIFF
--- a/src/components/transactionHistory/TransactionItem.vue
+++ b/src/components/transactionHistory/TransactionItem.vue
@@ -1,0 +1,63 @@
+<template>
+  <article class="transaction-item">
+    <div class="transaction-item__left">
+      <img class="transaction-item__img" src="" alt="" />
+      <div class="transaction-item__content">
+        <p class="transaction-item__title">거래명</p>
+        <p class="transaction-item__desc">2025.04.07 | 메모메모</p>
+      </div>
+    </div>
+    <div class="transaction-item__right">
+      <p class="transaction-item__amount">00,000원</p>
+      <i class="fa-solid fa-ellipsis-vertical" style="color: #aeaeae"></i>
+    </div>
+  </article>
+</template>
+
+<style scoped>
+.transaction-item {
+  display: flex;
+  justify-content: space-between;
+}
+
+.transaction-item__left {
+  display: flex;
+  align-items: center;
+}
+
+.transaction-item__content {
+  margin-left: 12px;
+}
+
+.transaction-item__img {
+  clip-path: circle(50%);
+  height: 42px;
+  background-color: gray;
+  width: 42px;
+}
+
+.transaction-item__title {
+  font-size: 16px;
+  padding: 0;
+  margin: 0;
+}
+
+.transaction-item__desc {
+  font-size: 10px;
+  color: #8d8d8d;
+  padding: 0;
+  margin: 4px 0 0 0;
+}
+
+.transaction-item__right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.transaction-item__amount {
+  margin-right: 12px;
+}
+</style>
+
+<script setup></script>

--- a/src/components/transactionHistory/TransactionItem.vue
+++ b/src/components/transactionHistory/TransactionItem.vue
@@ -11,7 +11,10 @@
     </div>
     <div class="transaction-item__right">
       <p class="transaction-item__amount">{{ data.transactionAmount }}원</p>
-      <i class="fa-solid fa-ellipsis-vertical" style="color: #aeaeae"></i>
+      <i
+        class="fa-solid fa-ellipsis-vertical"
+        style="color: #aeaeae; padding: 10px"
+      ></i>
     </div>
   </article>
 </template>
@@ -68,10 +71,13 @@ import { defineProps } from 'vue';
 const props = defineProps({
   data: {
     transactionId: Number,
-    transactionTitle: String,
+    userId: Number,
+    flowType: String,
     transactionDate: String,
-    transactionMemo: String,
     transactionAmount: Number,
+    transactionCategory: String,
+    transactionTitle: String,
+    transactionMemo: String,
   },
 });
 </script>

--- a/src/components/transactionHistory/TransactionItem.vue
+++ b/src/components/transactionHistory/TransactionItem.vue
@@ -3,12 +3,14 @@
     <div class="transaction-item__left">
       <img class="transaction-item__img" src="" alt="" />
       <div class="transaction-item__content">
-        <p class="transaction-item__title">거래명</p>
-        <p class="transaction-item__desc">2025.04.07 | 메모메모</p>
+        <p class="transaction-item__title">{{ data.transactionTitle }}</p>
+        <p class="transaction-item__desc">
+          {{ data.transactionDate }} | {{ data.transactionMemo }}
+        </p>
       </div>
     </div>
     <div class="transaction-item__right">
-      <p class="transaction-item__amount">00,000원</p>
+      <p class="transaction-item__amount">{{ data.transactionAmount }}원</p>
       <i class="fa-solid fa-ellipsis-vertical" style="color: #aeaeae"></i>
     </div>
   </article>
@@ -60,4 +62,16 @@
 }
 </style>
 
-<script setup></script>
+<script setup>
+import { defineProps } from 'vue';
+
+const props = defineProps({
+  data: {
+    transactionId: Number,
+    transactionTitle: String,
+    transactionDate: String,
+    transactionMemo: String,
+    transactionAmount: Number,
+  },
+});
+</script>

--- a/src/components/transactionHistory/TransactionList.vue
+++ b/src/components/transactionHistory/TransactionList.vue
@@ -1,0 +1,60 @@
+<template>
+  <ul
+    class="transaction-list"
+    v-for="(transaction, index) in formattedTransactions"
+    :key="index"
+  >
+    <li>
+      <transaction-item
+        :data="{
+          transactionId: transaction.id,
+          transactionUserId: transaction.user_id,
+          transactionFlowType: transaction.flow_type,
+          transactionDate: transaction.date,
+          transactionAmount: transaction.amount,
+          transactionCategory: transaction.category,
+          transactionTitle: transaction.category,
+          transactionMemo: transaction.memo,
+        }"
+      />
+    </li>
+  </ul>
+</template>
+
+<style scoped>
+.transaction-list {
+  list-style: none;
+  padding: 10px 0;
+  margin: 0;
+}
+</style>
+
+<script setup>
+import TransactionItem from './TransactionItem.vue';
+import { reactive, computed } from 'vue';
+import { formatDateToShort } from './formatDate.js';
+
+const baseTransaction = {
+  user_id: 1,
+  flow_type: '지출',
+  date: '2025-04-02T12:30:00',
+  amount: 12000,
+  category: '식비',
+  memo: '회사 근처 식당',
+  payment: '신용/체크',
+};
+
+const state = reactive({
+  transactions: Array.from({ length: 10 }, (_, i) => ({
+    ...baseTransaction,
+    id: i + 1,
+  })),
+});
+
+const formattedTransactions = computed(() =>
+  state.transactions.map((tx) => ({
+    ...tx,
+    date: formatDateToShort(tx.date),
+  }))
+);
+</script>

--- a/src/components/transactionHistory/formatDate.js
+++ b/src/components/transactionHistory/formatDate.js
@@ -1,0 +1,18 @@
+/**
+ * 날짜 문자열을 'YY.MM.DD' 형식으로 변환
+ * @param {string} isoDate - 예: '2025-04-01T00:00:00'
+ * @returns {string} - 예: '25.04.01'
+ */
+export function formatDateToShort(isoDate) {
+  if (!isoDate) return '';
+
+  const date = new Date(isoDate);
+
+  if (isNaN(date.getTime())) return '';
+
+  const year = String(date.getFullYear()).slice(2);
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `${year}.${month}.${day}`;
+}

--- a/src/pages/TransactionHistory/TranscationHistory.vue
+++ b/src/pages/TransactionHistory/TranscationHistory.vue
@@ -1,17 +1,32 @@
 <template>
-  <section class="transaction-list">
-    <div class="transaction-list__filter">
-      <span class="transaction-list__filter__label">최신순</span>
-      <i
-        class="fa-solid fa-angle-down icon"
-        style="color: #dedede; padding: 3px"
-      ></i>
-    </div>
-    <transaction-list />
-  </section>
+  <div class="app-wrapper">
+    <section class="transaction-list">
+      <div class="transaction-list__filter">
+        <span class="transaction-list__filter__label">최신순</span>
+        <i
+          class="fa-solid fa-angle-down icon"
+          style="color: #dedede; padding: 3px"
+        ></i>
+      </div>
+      <transaction-list />
+    </section>
+  </div>
 </template>
 
 <style scoped>
+.app-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  width: 100vw;
+}
+
+.transaction-list {
+  width: 375px;
+  height: 667px;
+}
+
 .transaction-list__filter {
   display: flex;
   width: 100%;

--- a/src/pages/TransactionHistory/TranscationHistory.vue
+++ b/src/pages/TransactionHistory/TranscationHistory.vue
@@ -1,0 +1,31 @@
+<template>
+  <section class="transaction-list">
+    <div class="transaction-list__filter">
+      <span class="transaction-list__filter__label">최신순</span>
+      <i
+        class="fa-solid fa-angle-down icon"
+        style="color: #dedede; padding: 3px"
+      ></i>
+    </div>
+    <transaction-list />
+  </section>
+</template>
+
+<style scoped>
+.transaction-list__filter {
+  display: flex;
+  width: 100%;
+  justify-content: right;
+  margin-left: auto;
+  align-items: center;
+}
+
+.transaction-list__filter__label {
+  font-size: 12px;
+  color: #8d8d8d;
+}
+</style>
+
+<script setup>
+import TransactionList from '@/components/transactionHistory/TransactionList.vue';
+</script>


### PR DESCRIPTION
## 📌 Issues
- closed #2 

## 🏁 Work Description
- 거래내역 리스트 아이템 컴포넌트 구현
- 거래내역 리스트 컴포넌트 구현
- 거래내역 리스트 연결
- DATE 포멧 유틸 구현

## 💬 PR Points
- date 포멧 유틸 구현했습니다. (머지 후 파일 위치는 util로 옮겨놓을게요)
   -  `formatDateToShort(date)` 이런식으로 import 하셔서 사용하시면 됩니다! 
```javascript
/**
 * 날짜 문자열을 'YY.MM.DD' 형식으로 변환
 * @param {string} isoDate - 예: '2025-04-01T00:00:00'
 * @returns {string} - 예: '25.04.01'
 */
export function formatDateToShort(isoDate) {
  if (!isoDate) return '';

  const date = new Date(isoDate);

  if (isNaN(date.getTime())) return '';

  const year = String(date.getFullYear()).slice(2);
  const month = String(date.getMonth() + 1).padStart(2, '0');
  const day = String(date.getDate()).padStart(2, '0');

  return `${year}.${month}.${day}`;
}
``` 

- 거래내역 아이템 컴포넌트 만들었습니다! home에서 사용하시고 싶으시면 props만 넣어서 사용하시면 됩니다.
```
const props = defineProps({
  data: {
    transactionId: Number,
    userId: Number,
    flowType: String,
    transactionDate: String,
    transactionAmount: Number,
    transactionCategory: String,
    transactionTitle: String,
    transactionMemo: String,
  },
});
``` 


## 📷 Screenshot
<img src="https://github.com/user-attachments/assets/158ab982-dba9-4094-bc19-e73903fe9f9f" width="400"/>

