### PR TITLE
feat: 카테고리 아이콘 컴포넌트

### DIFF
--- a/src/components/common/CategoryIcon.vue
+++ b/src/components/common/CategoryIcon.vue
@@ -7,11 +7,9 @@
   justify-content: center;
   align-items: center;
 
-  background-color: lightgray;
-
   border-radius: 50%;
   object-fit: contain;
-  color: black;
+  color: white;
 }
 </style>
 
@@ -19,9 +17,7 @@
   <div
     class="categoryIconContainer"
     :style="{
-      backgroundColor: isIncome
-        ? incomeIcons[incomeType][1]
-        : expenseIcons[expenseType][1],
+      backgroundColor,
     }"
   >
     <i :class="`fa-solid fa-${icon}`"></i>
@@ -32,12 +28,12 @@
 import { computed } from 'vue';
 import { defineProps } from 'vue';
 
-defineProps({
+const props = defineProps({
   //'수입' 혹은 '지출'
   categoryType: {
     type: String,
     default: '',
-    default: true,
+    required: true,
   },
   // 수입이라면 어떤 카테고리인지
   incomeType: {
@@ -53,27 +49,34 @@ defineProps({
 
 // 추후 상수 파일로 옮길 예정
 const incomeIcons = {
-  월급: ['briefcase'],
-  용돈: 'sack-dollar',
-  기타: 'folder-plus',
+  월급: ['briefcase', '#4CAF50'], // 녹색
+  용돈: ['sack-dollar', '#FFC107'], // 노란색
+  기타: ['folder-plus', '#03A9F4'], // 파란색
 };
 
 const expenseIcons = {
-  식비: 'utensils',
-  쇼핑: 'basket-shopping',
-  커피: 'mug-hot',
-  문화생활: 'masks-theater',
-  교통: 'car-side',
-  기타: 'folder-minus',
+  식비: ['utensils', '#FF5722'], // 주황색
+  쇼핑: ['basket-shopping', '#9C27B0'], // 보라색
+  커피: ['mug-hot', '#795548'], // 갈색
+  문화생활: ['masks-theater', '#673AB7'], // 진한 보라색
+  교통: ['car-side', '#2196F3'], // 파란색
+  기타: ['folder-minus', '#607D8B'], // 회색
 };
 
 // 수입인지 지출인지 저장
-const isIncome = categoryType;
+const isIncome = computed(() => props.categoryType === '수입');
 
 // 수입 지출 여부에 따라 아이콘 매칭
 const icon = computed(() => {
-  return isIncome.value === '수입'
-    ? incomeIcons[incomeType][0] || 'folder-plus'
-    : expenseIcons[expenseType][0] || 'folder-minus';
+  return isIncome.value
+    ? incomeIcons[props.incomeType]?.[0] || 'folder-plus'
+    : expenseIcons[props.expenseType]?.[0] || 'folder-minus';
+});
+
+// 수입 지출 여부에 따라 배경색 매칭
+const backgroundColor = computed(() => {
+  return isIncome.value
+    ? incomeIcons[props.incomeType]?.[1] || '#03A9F4' // 기본값: 파란색
+    : expenseIcons[props.expenseType]?.[1] || '#607D8B'; // 기본값: 회색
 });
 </script>

--- a/src/components/common/CategoryIcon.vue
+++ b/src/components/common/CategoryIcon.vue
@@ -1,0 +1,79 @@
+<style scoped>
+.categoryIconContainer {
+  width: 42px;
+  height: 42px;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  background-color: lightgray;
+
+  border-radius: 50%;
+  object-fit: contain;
+  color: black;
+}
+</style>
+
+<template>
+  <div
+    class="categoryIconContainer"
+    :style="{
+      backgroundColor: isIncome
+        ? incomeIcons[incomeType][1]
+        : expenseIcons[expenseType][1],
+    }"
+  >
+    <i :class="`fa-solid fa-${icon}`"></i>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { defineProps } from 'vue';
+
+defineProps({
+  //'수입' 혹은 '지출'
+  categoryType: {
+    type: String,
+    default: '',
+    default: true,
+  },
+  // 수입이라면 어떤 카테고리인지
+  incomeType: {
+    type: String,
+    default: '',
+  },
+  // 지출이라면 어떤 카테고리인지
+  expenseType: {
+    type: String,
+    default: '',
+  },
+});
+
+// 추후 상수 파일로 옮길 예정
+const incomeIcons = {
+  월급: ['briefcase'],
+  용돈: 'sack-dollar',
+  기타: 'folder-plus',
+};
+
+const expenseIcons = {
+  식비: 'utensils',
+  쇼핑: 'basket-shopping',
+  커피: 'mug-hot',
+  문화생활: 'masks-theater',
+  교통: 'car-side',
+  기타: 'folder-minus',
+};
+
+// 수입인지 지출인지 저장
+const isIncome = categoryType;
+
+// 수입 지출 여부에 따라 아이콘 매칭
+const icon = computed(() => {
+  return isIncome.value === '수입'
+    ? incomeIcons[incomeType][0] || 'folder-plus'
+    : expenseIcons[expenseType][0] || 'folder-minus';
+});
+</script>


### PR DESCRIPTION
## 📌 Issues
- closed #44 

## 🏁 Work Description
- 수입/지출과 카테고리 이름에 따라 컴포넌트 색상과 아이콘이 변경되도록 구현하였습니다

## 💬 PR Points
### 카테고리 컴포넌트 사용법
- categoryType은 필수로 "수입" 혹은 "지출" 중에서 넘겨주기
- 수입의 경우 incomeType, 지출의 경우 expenseType 을 넘겨줍니다
```javascript
//사용예시
    <CategoryIcon :categoryType="'지출'" :expenseType="'커피'"></CategoryIcon>
```

## 📷 Screenshot
![image](https://github.com/user-attachments/assets/7d7248a6-b6f6-4b3d-ab57-5657d68381ab)


