### PR TITLE
[Feat/#17] : api service 기본 구조 세팅, 거래내역 get 연결 

### DIFF
--- a/src/components/transactionHistory/TransactionList.vue
+++ b/src/components/transactionHistory/TransactionList.vue
@@ -13,8 +13,8 @@
           transactionDate: transaction.date,
           transactionAmount: transaction.amount,
           transactionCategory: transaction.category,
-          transactionTitle: transaction.category,
-          transactionMemo: transaction.memo,
+          transactionTitle: transaction.memo,
+          transactionMemo: transaction.payment,
         }"
         @open="openModal"
       />
@@ -32,28 +32,14 @@
 
 <script setup>
 import TransactionItem from './TransactionItem.vue';
-import { reactive, computed } from 'vue';
+import { computed } from 'vue';
 import { formatDateToShort } from '../../util/formatDate.js';
+import { inject } from 'vue';
 
-const baseTransaction = {
-  user_id: 1,
-  flow_type: '지출',
-  date: '2025-04-02T12:30:00',
-  amount: 12000,
-  category: '식비',
-  memo: '회사 근처 식당',
-  payment: '신용/체크',
-};
-
-const state = reactive({
-  transactions: Array.from({ length: 10 }, (_, i) => ({
-    ...baseTransaction,
-    id: i + 1,
-  })),
-});
+const { transactions } = inject('transactionHistory');
 
 const formattedTransactions = computed(() =>
-  state.transactions.map((tx) => ({
+  transactions.value.map((tx) => ({
     ...tx,
     date: formatDateToShort(tx.date),
   }))

--- a/src/pages/TransactionHistory.vue
+++ b/src/pages/TransactionHistory.vue
@@ -143,18 +143,35 @@ import TransactionList from '@/components/transactionHistory/TransactionList.vue
 import Header from '@/components/common/Header.vue';
 import FilterBottomModal from '@/components/transactionHistory/FilterBottomModal.vue';
 import BottomModal from '@/components/transactionHistory/BottomModal.vue';
-
 import { COLORS } from '@/util/constants';
-import { ref } from 'vue';
+import { ref, provide, onMounted } from 'vue';
+import { TransactionService } from '@/util/apiService';
 
 const selectedType = ref('전체');
+const isFilterModalOpen = ref(false);
+const isEditModalOpen = ref(false);
+const transactions = ref([]);
+
+const fetchTransactions = async () => {
+  try {
+    const response = await TransactionService.get();
+    transactions.value = response.data;
+  } catch (error) {
+    console.error('거래내역 가져오기 실패:', error);
+  }
+};
+
+onMounted(() => {
+  fetchTransactions();
+});
+
+provide('transactionHistory', {
+  transactions,
+});
 
 const selectType = (type) => {
   selectedType.value = type;
 };
-
-const isFilterModalOpen = ref(false);
-const isEditModalOpen = ref(false);
 
 const openFilterModal = () => {
   isFilterModalOpen.value = true;

--- a/src/util/apiService.js
+++ b/src/util/apiService.js
@@ -2,30 +2,66 @@ import axios from 'axios';
 import { API_URL } from '@/util/constants.js';
 
 const ApiService = {
+  /**
+   * GET 요청을 실행하여 쿼리 파라미터를 전달합니다.
+   * @param {string} resource - 요청할 API 리소스 경로 (예: 'money')
+   * @param {object} params - Axios config 객체로, 주로 params: { key: value } 형태의 쿼리 파라미터
+   * @returns {Promise<AxiosResponse>} - Axios 응답 Promise
+   */
   query(resource, params) {
     return axios.get(`${API_URL}${resource}`, params).catch((error) => {
       throw new Error(`[RWV] ApiService ${error}`);
     });
   },
 
+  /**
+   * GET 요청을 실행합니다.
+   * @param {string} resource - 기본 리소스 경로 (예: 'money')
+   * @param {string} [slug=''] - 세부 리소스 ID 또는 경로 (예: '123' → 'money/123')
+   * @returns {Promise<AxiosResponse>} - Axios 응답 Promise
+   */
   get(resource, slug = '') {
     return axios.get(`${API_URL}${resource}/${slug}`).catch((error) => {
       throw new Error(`[RWV] ApiService ${error}`);
     });
   },
 
+  /**
+   * POST 요청을 실행합니다.
+   * @param {string} resource - 요청할 API 리소스 경로
+   * @param {object} params - 요청 본문에 포함될 데이터 (예: { name: 'Test' })
+   * @returns {Promise<AxiosResponse>} - Axios 응답 Promise
+   */
   post(resource, params) {
     return axios.post(`${API_URL}${resource}`, params);
   },
 
+  /**
+   * PUT 요청 (리소스 ID 포함)을 실행합니다.
+   * @param {string} resource - 리소스 경로
+   * @param {string} slug - 리소스 식별자 (예: '123')
+   * @param {object} params - 업데이트할 데이터
+   * @returns {Promise<AxiosResponse>} - Axios 응답 Promise
+   */
   update(resource, slug, params) {
     return axios.put(`${API_URL}${resource}/${slug}`, params);
   },
 
+  /**
+   * PUT 요청 (리소스 ID 없이)을 실행합니다.
+   * @param {string} resource - 리소스 경로
+   * @param {object} params - 업데이트할 데이터
+   * @returns {Promise<AxiosResponse>} - Axios 응답 Promise
+   */
   put(resource, params) {
     return axios.put(`${API_URL}${resource}`, params);
   },
 
+  /**
+   * DELETE 요청을 실행합니다.
+   * @param {string} resource - 삭제할 리소스 경로 또는 ID 포함 경로
+   * @returns {Promise<AxiosResponse>} - Axios 응답 Promise
+   */
   delete(resource) {
     return axios.delete(`${API_URL}${resource}`).catch((error) => {
       throw new Error(`[RWV] ApiService ${error}`);
@@ -35,7 +71,14 @@ const ApiService = {
 
 export default ApiService;
 
+/**
+ * 거래 내역 관련 API 서비스
+ */
 export const TransactionService = {
+  /**
+   * 거래 내역 전체를 조회합니다.
+   * @returns {Promise<AxiosResponse>} - 거래 데이터 리스트 반환
+   */
   get() {
     return ApiService.get('money');
   },

--- a/src/util/apiService.js
+++ b/src/util/apiService.js
@@ -1,0 +1,42 @@
+import axios from 'axios';
+import { API_URL } from '@/util/constants.js';
+
+const ApiService = {
+  query(resource, params) {
+    return axios.get(`${API_URL}${resource}`, params).catch((error) => {
+      throw new Error(`[RWV] ApiService ${error}`);
+    });
+  },
+
+  get(resource, slug = '') {
+    return axios.get(`${API_URL}${resource}/${slug}`).catch((error) => {
+      throw new Error(`[RWV] ApiService ${error}`);
+    });
+  },
+
+  post(resource, params) {
+    return axios.post(`${API_URL}${resource}`, params);
+  },
+
+  update(resource, slug, params) {
+    return axios.put(`${API_URL}${resource}/${slug}`, params);
+  },
+
+  put(resource, params) {
+    return axios.put(`${API_URL}${resource}`, params);
+  },
+
+  delete(resource) {
+    return axios.delete(`${API_URL}${resource}`).catch((error) => {
+      throw new Error(`[RWV] ApiService ${error}`);
+    });
+  },
+};
+
+export default ApiService;
+
+export const TransactionService = {
+  get() {
+    return ApiService.get('money');
+  },
+};

--- a/src/util/constants.js
+++ b/src/util/constants.js
@@ -12,4 +12,4 @@ export const COLORS = {
   WHITE: '#FDFDFD',
 };
 
-export const API_URL = '/api'; // API URL
+export const API_URL = '/api';

--- a/src/util/constants.js
+++ b/src/util/constants.js
@@ -1,13 +1,15 @@
 export const COLORS = {
-	// 숫자가 높을수록 진한 색입니다
-	GREEN01: "#CEF9ED",
-	GREEN02: "#55EFC4", //프라이머리 컬러
-	GRAY00: "#F7F7F7",
-	GRAY01: "#D9D9D9",
-	GRAY02: "#8D8D8D",
-	GRAY03: "#434343",
-	GRAY04: "#AEAEAE",
-	BLUE01: "8BBFFF",
-	BLACK: "#000000",
-	WHITE: "#FDFDFD",
+  // 숫자가 높을수록 진한 색입니다
+  GREEN01: '#CEF9ED',
+  GREEN02: '#55EFC4', //프라이머리 컬러
+  GRAY00: '#F7F7F7',
+  GRAY01: '#D9D9D9',
+  GRAY02: '#8D8D8D',
+  GRAY03: '#434343',
+  GRAY04: '#AEAEAE',
+  BLUE01: '8BBFFF',
+  BLACK: '#000000',
+  WHITE: '#FDFDFD',
 };
+
+export const API_URL = '/api'; // API URL

--- a/vite.config.js
+++ b/vite.config.js
@@ -16,4 +16,13 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    },
+  },
 });


### PR DESCRIPTION
## 📌 Issues
- closed #17

## 🏁 Work Description
- api service 기본 구조 세팅
- 거래내역 get 연결

## 💬 PR Points
- util 하위에 api service 만들었습니다! 사용하시고 싶으시면 아래처럼 사용하시면 됩니다
1. apiService에 사용하려는 함수 등록 및 export 
```javascript
//apiService.js
/**
 * 거래 내역 관련 API 서비스
 */
export const TransactionService = {
  /**
   * 거래 내역 전체를 조회합니다.
   * @returns {Promise<AxiosResponse>} - 거래 데이터 리스트 반환
   */
  get() {
    return ApiService.get('money');
  },
};
``` 
  2. 호출
```javascript
const fetchTransactions = async () => {
  try {
    const response = await TransactionService.get();
    transactions.value = response.data;
  } catch (error) {
    console.error('거래내역 가져오기 실패:', error);
  }
};
``` 

## 📷 Screenshot
<img src="https://github.com/user-attachments/assets/81954485-b294-4d15-a6f6-525b17474627" width="400"/>

