### PR TITLE
[Feat/#57] : 거래내역 필터링 로직, 데스크탑 뷰

### DIFF
--- a/src/components/transactionHistory/EmptyView.vue
+++ b/src/components/transactionHistory/EmptyView.vue
@@ -1,0 +1,20 @@
+<template>
+  <div class="empty-view">
+    <p class="empty-text">거래 내역이 없습니다 😢</p>
+  </div>
+</template>
+
+<script setup>
+// 별도 props는 필요 없음
+</script>
+
+<style scoped>
+.empty-view {
+  padding: 40px;
+  text-align: center;
+}
+.empty-text {
+  color: #b0b0b0;
+  font-size: 14px;
+}
+</style>

--- a/src/components/transactionHistory/TransactionItem.vue
+++ b/src/components/transactionHistory/TransactionItem.vue
@@ -1,7 +1,10 @@
 <template>
   <article class="transaction-item">
     <div class="transaction-item__left">
-      <img class="transaction-item__img" src="" alt="" />
+      <category-icon
+        :categoryType="data.transactionFlowType"
+        :expenseType="data.transactionCategory"
+      />
       <div class="transaction-item__content">
         <p class="transaction-item__title">{{ data.transactionTitle }}</p>
         <p class="transaction-item__desc" :style="{ color: COLORS.GRAY02 }">
@@ -88,6 +91,7 @@
 <script setup>
 import { defineProps } from 'vue';
 import { COLORS } from '@/util/constants';
+import CategoryIcon from '@/components/common/CategoryIcon.vue';
 
 const props = defineProps({
   data: {

--- a/src/components/transactionHistory/TransactionItem.vue
+++ b/src/components/transactionHistory/TransactionItem.vue
@@ -22,7 +22,7 @@
         {{ data.transactionAmount }}원
       </p>
       <i
-        class="fa-solid fa-ellipsis-vertical"
+        class="fa-solid fa-ellipsis-vertical pointer"
         style="color: #aeaeae; padding: 10px"
         @click="openModal"
       ></i>

--- a/src/components/transactionHistory/TransactionItem.vue
+++ b/src/components/transactionHistory/TransactionItem.vue
@@ -10,7 +10,14 @@
       </div>
     </div>
     <div class="transaction-item__right">
-      <p class="transaction-item__amount">{{ data.transactionAmount }}원</p>
+      <p
+        class="transaction-item__amount"
+        :style="{
+          color: data.transactionFlowType === '지출' ? COLORS.RED : COLORS.BLUE,
+        }"
+      >
+        {{ data.transactionAmount }}원
+      </p>
       <i
         class="fa-solid fa-ellipsis-vertical"
         style="color: #aeaeae; padding: 10px"
@@ -86,7 +93,7 @@ const props = defineProps({
   data: {
     transactionId: Number,
     userId: Number,
-    flowType: String,
+    transactionFlowType: String,
     transactionDate: String,
     transactionAmount: Number,
     transactionCategory: String,

--- a/src/components/transactionHistory/TransactionList.vue
+++ b/src/components/transactionHistory/TransactionList.vue
@@ -34,18 +34,22 @@
 import TransactionItem from './TransactionItem.vue';
 import { computed } from 'vue';
 import { formatDateToShort } from '../../util/formatDate.js';
-import { inject } from 'vue';
 
-const { transactions } = inject('transactionHistory');
+const props = defineProps({
+  transactions: {
+    type: Array,
+    required: true,
+  },
+});
+
+const emit = defineEmits(['open']);
 
 const formattedTransactions = computed(() =>
-  transactions.value.map((tx) => ({
+  props.transactions.map((tx) => ({
     ...tx,
     date: formatDateToShort(tx.date),
   }))
 );
-
-const emit = defineEmits(['open']);
 
 const openModal = (id) => {
   emit('open', id);

--- a/src/components/transactionHistory/TransactionList.vue
+++ b/src/components/transactionHistory/TransactionList.vue
@@ -8,7 +8,7 @@
       <transaction-item
         :data="{
           transactionId: transaction.id,
-          transactionUserId: transaction.user_id,
+          userId: transaction.user_id,
           transactionFlowType: transaction.flow_type,
           transactionDate: transaction.date,
           transactionAmount: transaction.amount,

--- a/src/components/transactionHistory/TransactionSummary.vue
+++ b/src/components/transactionHistory/TransactionSummary.vue
@@ -1,0 +1,90 @@
+<template>
+  <section class="transaction-info">
+    <div
+      class="transaction-info__balance"
+      :style="{ backgroundColor: COLORS.GREEN01 }"
+    >
+      <span class="transaction-info__balance__amount">{{
+        calculateTotalAmount()
+      }}</span>
+    </div>
+    <div class="transaction-info__summary">
+      <div
+        :style="{
+          backgroundColor:
+            selectedType === '수입' ? COLORS.GRAY03 : COLORS.GREEN01,
+          color: selectedType === '수입' ? COLORS.WHITE : COLORS.GRAY02,
+        }"
+        @click="$emit('selectType', '수입')"
+      >
+        <span>수입</span><br />
+        <span
+          :style="{
+            color: selectedType === '수입' ? COLORS.WHITE : COLORS.BLUE,
+          }"
+        >
+          {{ sumTransactionsAmount('수입') }}원
+        </span>
+      </div>
+      <div
+        :style="{
+          backgroundColor:
+            selectedType === '지출' ? COLORS.GRAY03 : COLORS.GREEN01,
+          color: selectedType === '지출' ? COLORS.WHITE : COLORS.GRAY02,
+        }"
+        @click="$emit('selectType', '지출')"
+      >
+        <span>지출</span><br />
+        <span
+          :style="{
+            color: selectedType === '지출' ? COLORS.WHITE : COLORS.RED,
+          }"
+        >
+          {{ sumTransactionsAmount('지출') }}원
+        </span>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.transaction-info {
+  margin: 0 16px;
+  display: flex;
+  flex-direction: column;
+}
+.transaction-info__balance {
+  padding: 22px 20px;
+  margin-top: 20px;
+  border-radius: 16px;
+}
+.transaction-info__balance__amount {
+  font-size: 20px;
+  display: flex;
+  justify-content: center;
+}
+.transaction-info__summary {
+  margin: 20px 0 24px;
+  display: flex;
+  justify-content: space-around;
+}
+.transaction-info__summary > div {
+  width: 100%;
+  padding: 20px;
+  border-radius: 16px;
+  text-align: center;
+}
+.transaction-info__summary > div:first-child {
+  margin-right: 20px;
+}
+</style>
+
+<script setup>
+import { COLORS } from '@/util/constants';
+
+const props = defineProps({
+  selectedType: String,
+  calculateTotalAmount: Function,
+  sumTransactionsAmount: Function,
+});
+</script>

--- a/src/components/transactionHistory/TransactionSummary.vue
+++ b/src/components/transactionHistory/TransactionSummary.vue
@@ -8,7 +8,7 @@
         calculateTotalAmount()
       }}</span>
     </div>
-    <div class="transaction-info__summary">
+    <div class="transaction-info__summary pointer">
       <div
         :style="{
           backgroundColor:
@@ -56,7 +56,7 @@
 .transaction-info__balance {
   padding: 22px 20px;
   margin-top: 20px;
-  border-radius: 16px;
+  border-radius: 12px;
 }
 .transaction-info__balance__amount {
   font-size: 20px;
@@ -71,9 +71,12 @@
 .transaction-info__summary > div {
   width: 100%;
   padding: 20px;
-  border-radius: 16px;
+  border-radius: 12px;
   text-align: center;
+  cursor: pointer;
+  transition: background-color 0.3s;
 }
+
 .transaction-info__summary > div:first-child {
   margin-right: 20px;
 }

--- a/src/pages/TransactionHistory.vue
+++ b/src/pages/TransactionHistory.vue
@@ -1,54 +1,16 @@
 <template>
   <div class="layout" :style="{ backgroundColor: COLORS.GREEN02 }">
     <header>
-      <Header :pageName="'거래 내역'"></Header>
+      <Header :pageName="'거래 내역'" />
     </header>
-    <section class="transaction-info">
-      <div
-        class="transaction-info__balance"
-        :style="{ backgroundColor: COLORS.GREEN01 }"
-      >
-        <span class="transaction-info__balance__amount">{{
-          calculateTotalAmount()
-        }}</span>
-      </div>
-      <div class="transaction-info__summary">
-        <div
-          :style="{
-            backgroundColor:
-              selectedType === '수입' ? COLORS.GRAY03 : COLORS.GREEN01,
-            color: selectedType === '수입' ? COLORS.WHITE : COLORS.GRAY02,
-          }"
-          @click="selectType('수입')"
-        >
-          <span>수입</span>
-          <br />
-          <span
-            :style="{
-              color: selectedType === '수입' ? COLORS.WHITE : COLORS.BLUE,
-            }"
-            >{{ sumTransactionsAmount('수입') }}원</span
-          >
-        </div>
-        <div
-          :style="{
-            backgroundColor:
-              selectedType === '지출' ? COLORS.GRAY03 : COLORS.GREEN01,
-            color: selectedType === '지출' ? COLORS.WHITE : COLORS.GRAY02,
-          }"
-          @click="selectType('지출')"
-        >
-          <span>지출</span>
-          <br />
-          <span
-            :style="{
-              color: selectedType === '지출' ? COLORS.WHITE : COLORS.RED,
-            }"
-            >{{ sumTransactionsAmount('지출') }}원</span
-          >
-        </div>
-      </div>
-    </section>
+
+    <TransactionSummary
+      :selectedType="selectedType"
+      :calculateTotalAmount="calculateTotalAmount"
+      :sumTransactionsAmount="sumTransactionsAmount"
+      @selectType="selectType"
+    />
+
     <section
       class="transaction-list"
       :style="{ backgroundColor: COLORS.WHITE }"
@@ -57,38 +19,31 @@
         <span
           class="transaction-list__filter__label"
           :style="{ color: COLORS.GRAY02 }"
-          >{{ filters.type }} | {{ filters.category }} |
-          {{ filters.date }}</span
         >
+          {{ filters.type || '전체' }} | {{ filters.category || '전체' }} |
+          {{ filters.date || '최신순' }}
+        </span>
         <i
           class="fa-solid fa-angle-down icon"
           style="color: #dedede; padding: 6px; margin-right: 25px"
-        ></i>
+        />
       </div>
 
-      <div v-if="filteredTransactions.length === 0" class="empty-view">
-        <p
-          :style="{
-            color: COLORS.GRAY02,
-            textAlign: 'center',
-            marginTop: '40px',
-          }"
-        >
-          거래 내역이 없습니다 😢
-        </p>
-      </div>
+      <EmptyView v-if="filteredTransactions.length === 0" />
 
-      <transaction-list
+      <TransactionList
+        v-else
         :transactions="filteredTransactions"
         @open="openEditModal"
       />
     </section>
-    <filter-bottom-modal
+
+    <FilterBottomModal
       :type="filters.type"
       :isOpen="isFilterModalOpen"
       @close="closeFilterModal"
     />
-    <bottom-modal
+    <BottomModal
       :isOpen="isEditModalOpen"
       @close="closeEditModal"
       @delete="deleteTransaction"
@@ -97,75 +52,30 @@
 </template>
 
 <style scoped>
-.transaction-info {
-  margin-left: 16px;
-  margin-right: 16px;
-
-  display: flex;
-  flex-direction: column;
-}
-
-.transaction-info__badge > * {
-  margin-right: 10px;
-}
-
-.transaction-info__balance {
-  padding: 22px 20px;
-  margin-top: 20px;
-  border-radius: 16px;
-}
-
-.transaction-info__balance__amount {
-  font-size: 20px;
-
-  display: flex;
-  justify-content: center;
-}
-
-.transaction-info__summary {
-  margin-bottom: 24px;
-  margin-top: 20px;
-
-  display: flex;
-  justify-content: space-around;
-}
-
-.transaction-info__summary > div {
-  width: 100%;
-  padding: 20px;
-  border-radius: 16px;
-  text-align: center;
-}
-
-.transaction-info__summary > div:first-child {
-  margin-right: 20px;
-}
-
 .transaction-list {
   width: 100%;
   margin-top: 15px;
   padding-top: 15px;
   border-radius: 16px 16px 0 0;
 }
-
 .transaction-list__filter {
   width: 100%;
   margin-left: auto;
   margin-top: 15px;
-
   display: flex;
   align-items: center;
   justify-content: right;
 }
-
 .transaction-list__filter__label {
   font-size: 12px;
 }
 </style>
 
 <script setup>
-import TransactionList from '@/components/transactionHistory/TransactionList.vue';
 import Header from '@/components/common/Header.vue';
+import TransactionList from '@/components/transactionHistory/TransactionList.vue';
+import TransactionSummary from '@/components/transactionHistory/TransactionSummary.vue';
+import EmptyView from '@/components/transactionHistory/EmptyView.vue';
 import FilterBottomModal from '@/components/transactionHistory/FilterBottomModal.vue';
 import BottomModal from '@/components/transactionHistory/BottomModal.vue';
 import { COLORS } from '@/util/constants';
@@ -193,29 +103,25 @@ const fetchTransactions = async () => {
   }
 };
 
-//필터링 및 정렬된 거래내역
 const filteredTransactions = computed(() => {
   return transactions.value
     .filter((tx) => {
-      //type 필터
       if (filters.type && filters.type !== '전체') {
         return tx.flow_type === filters.type;
       }
       return true;
     })
     .filter((tx) => {
-      //category 필터
       if (filters.category && filters.category !== '전체') {
         return tx.category === filters.category;
       }
       return true;
     })
     .sort((a, b) => {
-      //정렬: 최신순 또는 오래된순
       const dateA = new Date(a.date);
       const dateB = new Date(b.date);
       if (filters.date === '오래된 순') return dateA - dateB;
-      return dateB - dateA; // 최신순이 기본
+      return dateB - dateA;
     });
 });
 
@@ -229,7 +135,6 @@ const selectType = (type) => {
 const deleteTransaction = async () => {
   try {
     await TransactionService.delete(transactionId.value);
-
     transactions.value = transactions.value.filter(
       (tx) => tx.id !== transactionId.value
     );

--- a/src/pages/TransactionHistory.vue
+++ b/src/pages/TransactionHistory.vue
@@ -57,11 +57,12 @@
         <span
           class="transaction-list__filter__label"
           :style="{ color: COLORS.GRAY02 }"
-          >최신순</span
+          >{{ filters.type }} | {{ filters.category }} |
+          {{ filters.date }}</span
         >
         <i
           class="fa-solid fa-angle-down icon"
-          style="color: #dedede; padding: 3px; margin-right: 25px"
+          style="color: #dedede; padding: 6px; margin-right: 25px"
         ></i>
       </div>
       <transaction-list

--- a/src/pages/TransactionHistory.vue
+++ b/src/pages/TransactionHistory.vue
@@ -107,11 +107,10 @@ main {
 
   .transaction-list {
     margin-top: 0;
-    padding: 24px;
-    border-radius: 24px;
     flex: 1 1 60%;
-    border: 1px solid rgba(0, 0, 0, 0.06); /* 테두리 추가 */
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.03);
+    border-radius: 12px;
+    padding: 16px;
+    box-shadow: 0 3px 6px rgba(0, 0, 0, 0.1);
   }
 
   .transaction-list__filter__label {

--- a/src/pages/TransactionHistory.vue
+++ b/src/pages/TransactionHistory.vue
@@ -1,63 +1,79 @@
 <template>
-  <div class="layout" :style="{ backgroundColor: COLORS.GREEN02 }">
+  <div class="layout">
     <header>
       <Header :pageName="'거래 내역'" />
     </header>
 
-    <TransactionSummary
-      :selectedType="selectedType"
-      :calculateTotalAmount="calculateTotalAmount"
-      :sumTransactionsAmount="sumTransactionsAmount"
-      @selectType="selectType"
-    />
-
-    <section
-      class="transaction-list"
-      :style="{ backgroundColor: COLORS.WHITE }"
-    >
-      <div class="transaction-list__filter pointer" @click="openFilterModal">
-        <span
-          class="transaction-list__filter__label"
-          :style="{ color: COLORS.GRAY02 }"
-        >
-          {{ filters.type || '전체' }} | {{ filters.category || '전체' }} |
-          {{ filters.date || '최신순' }}
-        </span>
-        <i
-          class="fa-solid fa-angle-down icon"
-          style="color: #dedede; padding: 6px; margin-right: 25px"
-        />
-      </div>
-
-      <EmptyView v-if="filteredTransactions.length === 0" />
-
-      <TransactionList
-        v-else
-        :transactions="filteredTransactions"
-        @open="openEditModal"
+    <main>
+      <TransactionSummary
+        class="test"
+        :selectedType="selectedType"
+        :calculateTotalAmount="calculateTotalAmount"
+        :sumTransactionsAmount="sumTransactionsAmount"
+        @selectType="selectType"
       />
-    </section>
 
-    <FilterBottomModal
-      :type="filters.type"
-      :isOpen="isFilterModalOpen"
-      @close="closeFilterModal"
-    />
-    <BottomModal
-      :isOpen="isEditModalOpen"
-      @close="closeEditModal"
-      @delete="deleteTransaction"
-    />
+      <section
+        class="transaction-list"
+        :style="{ backgroundColor: COLORS.WHITE }"
+      >
+        <div class="transaction-list__filter pointer" @click="openFilterModal">
+          <span
+            class="transaction-list__filter__label"
+            :style="{ color: COLORS.GRAY02 }"
+          >
+            {{ filters.type || '전체' }} | {{ filters.category || '전체' }} |
+            {{ filters.date || '최신순' }}
+          </span>
+          <i
+            class="fa-solid fa-angle-down icon"
+            style="color: #dedede; padding: 6px; margin-right: 25px"
+          />
+        </div>
+
+        <EmptyView v-if="filteredTransactions.length === 0" />
+
+        <TransactionList
+          v-else
+          :transactions="filteredTransactions"
+          @open="openEditModal"
+        />
+      </section>
+
+      <FilterBottomModal
+        :type="filters.type"
+        :isOpen="isFilterModalOpen"
+        @close="closeFilterModal"
+      />
+      <BottomModal
+        :isOpen="isEditModalOpen"
+        @close="closeEditModal"
+        @delete="deleteTransaction"
+      />
+    </main>
   </div>
 </template>
 
 <style scoped>
+.layout {
+  display: flex;
+  flex-direction: column;
+  overflow-x: hidden;
+  background-color: v-bind('COLORS.GREEN02');
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+}
+
 .transaction-list {
   width: 100%;
   margin-top: 15px;
   padding-top: 15px;
   border-radius: 16px 16px 0 0;
 }
+
 .transaction-list__filter {
   width: 100%;
   margin-left: auto;
@@ -66,8 +82,41 @@
   align-items: center;
   justify-content: right;
 }
+
 .transaction-list__filter__label {
   font-size: 12px;
+}
+
+@media (min-width: 768px) {
+  .layout {
+    background-color: white;
+  }
+
+  main {
+    width: 100%;
+    max-width: 1200px;
+    margin: 50px auto;
+    display: flex;
+    flex-direction: row;
+    gap: 32px;
+  }
+
+  .test {
+    flex: 1 1 40%;
+  }
+
+  .transaction-list {
+    margin-top: 0;
+    padding: 24px;
+    border-radius: 24px;
+    flex: 1 1 60%;
+    border: 1px solid rgba(0, 0, 0, 0.06); /* 테두리 추가 */
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.03);
+  }
+
+  .transaction-list__filter__label {
+    font-size: 14px;
+  }
 }
 </style>
 

--- a/src/pages/TransactionHistory.vue
+++ b/src/pages/TransactionHistory.vue
@@ -6,7 +6,7 @@
 
     <main>
       <TransactionSummary
-        class="test"
+        class="transaction-summary"
         :selectedType="selectedType"
         :calculateTotalAmount="calculateTotalAmount"
         :sumTransactionsAmount="sumTransactionsAmount"
@@ -89,7 +89,7 @@ main {
 
 @media (min-width: 768px) {
   .layout {
-    background-color: white;
+    background-color: #fdfdfd;
   }
 
   main {
@@ -98,19 +98,23 @@ main {
     margin: 50px auto;
     display: flex;
     flex-direction: row;
-    gap: 32px;
+    gap: 10px;
   }
 
-  .test {
+  .transaction-summary {
     flex: 1 1 40%;
+    align-self: flex-start;
+    border-radius: 12px;
+    padding: 16px;
+    box-shadow: 0 3px 6px rgba(0, 0, 0, 0.1);
   }
 
   .transaction-list {
     margin-top: 0;
     flex: 1 1 60%;
-    border-radius: 12px;
-    padding: 16px;
-    box-shadow: 0 3px 6px rgba(0, 0, 0, 0.1);
+    padding: 12px;
+    border: 1px solid #eee;
+    border-radius: 16px;
   }
 
   .transaction-list__filter__label {

--- a/src/pages/TransactionHistory.vue
+++ b/src/pages/TransactionHistory.vue
@@ -65,6 +65,19 @@
           style="color: #dedede; padding: 6px; margin-right: 25px"
         ></i>
       </div>
+
+      <div v-if="filteredTransactions.length === 0" class="empty-view">
+        <p
+          :style="{
+            color: COLORS.GRAY02,
+            textAlign: 'center',
+            marginTop: '40px',
+          }"
+        >
+          거래 내역이 없습니다 😢
+        </p>
+      </div>
+
       <transaction-list
         :transactions="filteredTransactions"
         @open="openEditModal"

--- a/src/pages/TransactionHistory.vue
+++ b/src/pages/TransactionHistory.vue
@@ -206,6 +206,9 @@ const filteredTransactions = computed(() => {
 });
 
 const selectType = (type) => {
+  if (filters.type !== type) {
+    filters.category = '전체';
+  }
   filters.type = type;
 };
 


### PR DESCRIPTION
## 📌 Issues
- closed #57 

## 🏁 Work Description
- 거래내역 필터링 로직 구현
- 데스크탑 뷰 호환
- 거래내역 엠티뷰

## 💬 PR Points
- 데스크탑 뷰 디자인 홈이랑 최대한 통일성있게 맞춰봤는데, 수정하시고 싶으신 부분있으면 말해주세요!
- 타입(전체, 수입, 지출)이 새롭게 선택될 경우 카테고리는 전체로 리셋됩니다.
- 주석, css 정리는 새 pr로 반영해서 올리겠습니다!

## 📷 Screenshot

https://github.com/user-attachments/assets/c881ec4e-a56e-4938-b143-ba220bc7fed4


https://github.com/user-attachments/assets/581ff05a-32de-4877-a3f8-4b6ed77c38a9



